### PR TITLE
Add host to instantiated methods.

### DIFF
--- a/CCIProvider/TypeExtractor.cs
+++ b/CCIProvider/TypeExtractor.cs
@@ -545,10 +545,11 @@ namespace CCIProvider
 			CreateGenericParameterReferences(GenericParameterKind.Method, genericArguments.Count);
 
 			var method = ExtractReference(methodref.GenericMethod);
-			method = method.Instantiate(genericArguments);
+            var instantiatedMethod = method.Instantiate(genericArguments);
+            instantiatedMethod.Resolve(host);
 
-			BindGenericParameterReferences(GenericParameterKind.Method, method);
-			return method;
+            BindGenericParameterReferences(GenericParameterKind.Method, instantiatedMethod);
+			return instantiatedMethod;
 		}
 
 		public IMethodReference ExtractMethodReference(Cci.IMethodReference methodref)

--- a/MetadataProvider/AssemblyExtractor.cs
+++ b/MetadataProvider/AssemblyExtractor.cs
@@ -1305,10 +1305,11 @@ namespace MetadataProvider
 			CreateGenericParameterReferences(GenericParameterKind.Method, genericArguments.Length);
 
 			var method = GetMethodReference(methodspec.Method);
-			method = method.Instantiate(genericArguments);
+            var instantiatedMethod = method.Instantiate(genericArguments);
+            instantiatedMethod.Resolve(Host);
 
-			BindGenericParameterReferences(GenericParameterKind.Method, method);
-			return method;
+            BindGenericParameterReferences(GenericParameterKind.Method, instantiatedMethod);
+			return instantiatedMethod;
 		}
 
 		private IMethodReference GetMethodReference(SRM.EntityHandle handle)

--- a/MetadataProvider/SignatureTypeProvider.cs
+++ b/MetadataProvider/SignatureTypeProvider.cs
@@ -171,8 +171,9 @@ namespace MetadataProvider
 		public virtual IType GetGenericInstantiation(IType genericType, ImmutableArray<IType> genericArguments)
 		{
 			var result = genericType as IBasicType;
-			result = result.Instantiate(genericArguments);
-			return result;
+			var instantiated = result.Instantiate(genericArguments);
+            instantiated.Resolve(extractor.Host);
+			return instantiated;
 		}
 
 		public virtual IType GetArrayType(IType elementsType, SRM.ArrayShape shape)


### PR DESCRIPTION
Instantiate extension on MethodReferences is not initializing the host field. If you try to Resolve an instantiated method it fails because there is no host available.