### PR TITLE
Added new bytecode instruction Constrained.

### DIFF
--- a/CCIProvider/CodeProvider.cs
+++ b/CCIProvider/CodeProvider.cs
@@ -303,9 +303,9 @@ namespace CCIProvider
 				//    expression = new MethodCall() { Arguments = new List<IExpression>(1) { operand }, IsStaticCall = true, Type = operand.Type, MethodToCall = chkfinite };
 				//    break;
 
-				//case Cci.OperationCode.Constrained_:
-				//	// This prefix is redundant and is not represented in the code model.
-				//	break;
+				case Cci.OperationCode.Constrained_:
+                    instruction = ProcessConstrained(operation);
+                    break;
 
 				case Cci.OperationCode.Cpblk:
 					instruction = ProcessBasic(operation);
@@ -538,9 +538,16 @@ namespace CCIProvider
 			}
 
 			return instruction;
-		}
+        }
 
-		private IInstruction ProcessSwitch(Cci.IOperation op)
+        private IInstruction ProcessConstrained(Cci.IOperation op)
+        {
+            var thisType = typeExtractor.ExtractType(op.Value as Cci.ITypeReference);
+            var ins = new ConstrainedInstruction(op.Offset, thisType);
+            return ins;
+        }
+
+        private IInstruction ProcessSwitch(Cci.IOperation op)
 		{
 			var targets = op.Value as uint[];
 

--- a/MetadataProvider/AssemblyExtractor.cs
+++ b/MetadataProvider/AssemblyExtractor.cs
@@ -912,9 +912,9 @@ namespace MetadataProvider
 				//    expression = new MethodCall() { Arguments = new List<IExpression>(1) { operand }, IsStaticCall = true, Type = operand.Type, MethodToCall = chkfinite };
 				//    break;
 
-				//case SRM.ILOpCode.Constrained_:
-				//	// This prefix is redundant and is not represented in the code model.
-				//	break;
+				case SRM.ILOpCode.Constrained:
+                    instruction = ProcessConstrained(operation);
+					break;
 
 				case SRM.ILOpCode.Cpblk:
 					instruction = ProcessBasic(operation);
@@ -1391,8 +1391,14 @@ namespace MetadataProvider
 
 			parameters.Clear();
 		}
+        private IInstruction ProcessConstrained(ILInstruction op)
+        {
+            var thisType = GetOperand<IType>(op);
+            var ins = new ConstrainedInstruction(op.Offset, thisType);
+            return ins;
+        }
 
-		private IInstruction ProcessSwitch(ILInstruction op)
+        private IInstruction ProcessSwitch(ILInstruction op)
 		{
 			var targets = GetOperand<uint[]>(op);
 

--- a/Model/Bytecode/Instructions.cs
+++ b/Model/Bytecode/Instructions.cs
@@ -238,7 +238,29 @@ namespace Model.Bytecode
 			var targets = string.Join(", ", this.Targets);
 			return this.ToString("switch {0}", targets);
 		}
-	}
+    }
+
+    public class ConstrainedInstruction : Instruction
+    {
+        public IType ThisType { get; private set; }
+
+        public ConstrainedInstruction(uint label, IType thisType)
+            : base(label)
+        {
+            this.ThisType = thisType;
+        }
+
+        public override void Accept(IInstructionVisitor visitor)
+        {
+            base.Accept(visitor);
+            visitor.Visit(this);
+        }
+
+        public override string ToString()
+        {
+            return String.Format("constrain virtual call to type: {0}", ThisType.ToString());
+        }
+    }
 
 	public class CreateArrayInstruction : Instruction
 	{

--- a/Model/Bytecode/Visitor/IInstructionVisitor.cs
+++ b/Model/Bytecode/Visitor/IInstructionVisitor.cs
@@ -12,7 +12,8 @@ namespace Model.Bytecode.Visitor
 		void Visit(IInstructionContainer container);
 		void Visit(Instruction instruction);
 		void Visit(BasicInstruction instruction);
-		void Visit(LoadInstruction instruction);
+        void Visit(ConstrainedInstruction instruction);
+        void Visit(LoadInstruction instruction);
 		void Visit(LoadFieldInstruction instruction);
 		void Visit(LoadMethodAddressInstruction instruction);
 		void Visit(StoreInstruction instruction);

--- a/Model/Bytecode/Visitor/InstructionVisitor.cs
+++ b/Model/Bytecode/Visitor/InstructionVisitor.cs
@@ -20,7 +20,8 @@ namespace Model.Bytecode.Visitor
 
 		public virtual void Visit(Instruction instruction) { }
 		public virtual void Visit(BasicInstruction instruction) { }
-		public virtual void Visit(LoadInstruction instruction) { }
+        public virtual void Visit(ConstrainedInstruction instruction) { }
+        public virtual void Visit(LoadInstruction instruction) { }
 		public virtual void Visit(LoadFieldInstruction instruction) { }
 		public virtual void Visit(LoadMethodAddressInstruction instruction) { }
 		public virtual void Visit(StoreInstruction instruction) { }


### PR DESCRIPTION
In my opinion, there is no need to add a tac instruction. In case we want to go back from tac to simplified bytecode, it could be deduced by the type of the argument.