### PR TITLE
Added information required for explicit overrides (cci only)

### DIFF
--- a/CCIProvider/TypeExtractor.cs
+++ b/CCIProvider/TypeExtractor.cs
@@ -107,6 +107,7 @@ namespace CCIProvider
 			ExtractInterfaces(type.Interfaces, typedef.Interfaces);
 			ExtractFields(type, type.Fields, typedef.Fields);
 			ExtractMethods(type, type.Methods, typedef.Methods, sourceLocationProvider);
+			ExtractExplicitMethodOverrides(type, typedef.ExplicitImplementationOverrides);
 
 			defGenericContext.TypeParameters.Clear();
 			return type;
@@ -766,6 +767,16 @@ namespace CCIProvider
 			else result = TypeKind.ReferenceType;
 
 			return result;
+		}
+
+		private void ExtractExplicitMethodOverrides(TypeDefinition type, IEnumerable<Cci.IMethodImplementation> impls)
+		{
+			foreach (var impl in impls)
+			{
+				var implementedMethod = ExtractMethodReference(impl.ImplementedMethod);
+				var implementingMethod = ExtractMethodReference(impl.ImplementingMethod);
+				type.ExplicitOverrides.Add(new MethodImplementation(implementedMethod, implementingMethod));
+			}
 		}
 
 		private void ExtractMethods(TypeDefinition containingType, IList<MethodDefinition> dest, IEnumerable<Cci.IMethodDefinition> source, Cci.ISourceLocationProvider sourceLocationProvider)

--- a/Model/Types/TypeDefinitions.cs
+++ b/Model/Types/TypeDefinitions.cs
@@ -606,6 +606,18 @@ namespace Model.Types
 		Public = 8
 	}
 
+	public class MethodImplementation
+	{
+		public IMethodReference ImplementedMethod { get; private set; }
+		public IMethodReference ImplementingMethod { get; private set; }
+
+		public MethodImplementation(IMethodReference implemented, IMethodReference implementing)
+		{
+			this.ImplementedMethod = implemented;
+			this.ImplementingMethod = implementing;
+		}
+	}
+
 	public class TypeDefinition : IBasicType, IGenericDefinition, ITypeMemberDefinition, ITypeDefinitionContainer
 	{
 		public TypeKind TypeKind { get; set; }
@@ -623,6 +635,7 @@ namespace Model.Types
 		public IList<MethodDefinition> Methods { get; private set; }
 		public IList<TypeDefinition> Types { get; private set; }
 		public IBasicType UnderlayingType { get; set; }
+		public ISet<MethodImplementation> ExplicitOverrides { get; private set; }
 
 		public TypeDefinition(string name, TypeKind typeKind = TypeKind.Unknown, TypeDefinitionKind kind = TypeDefinitionKind.Unknown)
 		{
@@ -635,6 +648,7 @@ namespace Model.Types
 			this.Fields = new List<FieldDefinition>();
 			this.Methods = new List<MethodDefinition>();
 			this.Types = new List<TypeDefinition>();
+			this.ExplicitOverrides = new HashSet<MethodImplementation>();
 		}
 
 		public string GenericName


### PR DESCRIPTION
I wanted to create a field ISet<MethodReference> in each method definition. Then, use it to store all overrides made by the method definition. However, that implied to use MatchReference method and that required to have every other to model object to be fully created. In other words, it was not a simple task to do.