### PR TITLE
LoadArrayElementInstruction is not BasicInstruction anymore

### DIFF
--- a/Backend/Transformations/Disassembler.cs
+++ b/Backend/Transformations/Disassembler.cs
@@ -364,27 +364,6 @@ namespace Backend.Transformations
 				body.Instructions.Add(instruction);
 			}
 
-			private void ProcessLoadArrayElement(Bytecode.BasicInstruction op)
-			{
-				var index = stack.Pop();
-				var array = stack.Pop();
-				var dest = stack.Push();
-				var source = new ArrayElementAccess(array, index);
-				var instruction = new Tac.LoadInstruction(op.Offset, dest, source);
-				body.Instructions.Add(instruction);
-			}
-
-			private void ProcessLoadArrayElementAddress(Bytecode.BasicInstruction op)
-			{
-				var index = stack.Pop();
-				var array = stack.Pop();
-				var dest = stack.Push();
-				var access = new ArrayElementAccess(array, index);
-				var source = new Reference(access);
-				var instruction = new Tac.LoadInstruction(op.Offset, dest, source);
-				body.Instructions.Add(instruction);
-			}
-
 			private void ProcessIndirectStore(Bytecode.BasicInstruction op)
 			{
 				var source = stack.Pop();

--- a/Backend/Transformations/Disassembler.cs
+++ b/Backend/Transformations/Disassembler.cs
@@ -191,15 +191,7 @@ namespace Backend.Transformations
 					case Bytecode.BasicOperation.IndirectLoad:
 						ProcessIndirectLoad(op);
 						break;
-
-					case Bytecode.BasicOperation.LoadArrayElement:
-						ProcessLoadArrayElement(op);
-						break;
-
-					case Bytecode.BasicOperation.LoadArrayElementAddress:
-						ProcessLoadArrayElementAddress(op);
-						break;
-
+					
 					case Bytecode.BasicOperation.IndirectStore:
 						ProcessIndirectStore(op);
 						break;

--- a/CCIProvider/CodeProvider.cs
+++ b/CCIProvider/CodeProvider.cs
@@ -169,9 +169,6 @@ namespace CCIProvider
 
 				case Cci.OperationCode.Array_Get:
 				case Cci.OperationCode.Array_Addr:
-					instruction = ProcessLoadArrayElement(operation);
-                    break;
-
 				case Cci.OperationCode.Ldelem:
 				case Cci.OperationCode.Ldelem_I:
 				case Cci.OperationCode.Ldelem_I1:
@@ -184,12 +181,9 @@ namespace CCIProvider
 				case Cci.OperationCode.Ldelem_U2:
 				case Cci.OperationCode.Ldelem_U4:
 				case Cci.OperationCode.Ldelem_Ref:
-					instruction = ProcessBasic(operation);
-					break;
-
 				case Cci.OperationCode.Ldelema:
-					instruction = ProcessBasic(operation);
-					break;
+					instruction = ProcessLoadArrayElement(operation);
+                    break;
 
 				case Cci.OperationCode.Beq:
 				case Cci.OperationCode.Beq_S:

--- a/CCIProvider/OperationHelper.cs
+++ b/CCIProvider/OperationHelper.cs
@@ -69,19 +69,6 @@ namespace CCIProvider
 				case Cci.OperationCode.Ldind_U2:
 				case Cci.OperationCode.Ldind_U4:
 				case Cci.OperationCode.Ldobj:		return BasicOperation.IndirectLoad;
-				case Cci.OperationCode.Ldelem:
-				case Cci.OperationCode.Ldelem_I:
-				case Cci.OperationCode.Ldelem_I1:
-				case Cci.OperationCode.Ldelem_I2:
-				case Cci.OperationCode.Ldelem_I4:
-				case Cci.OperationCode.Ldelem_I8:
-				case Cci.OperationCode.Ldelem_R4:
-				case Cci.OperationCode.Ldelem_R8:
-				case Cci.OperationCode.Ldelem_U1:
-				case Cci.OperationCode.Ldelem_U2:
-				case Cci.OperationCode.Ldelem_U4:
-				case Cci.OperationCode.Ldelem_Ref:	return BasicOperation.LoadArrayElement;
-				case Cci.OperationCode.Ldelema:		return BasicOperation.LoadArrayElementAddress;
 				case Cci.OperationCode.Stind_I:
 				case Cci.OperationCode.Stind_I1:
 				case Cci.OperationCode.Stind_I2:

--- a/MetadataProvider/AssemblyExtractor.cs
+++ b/MetadataProvider/AssemblyExtractor.cs
@@ -780,9 +780,12 @@ namespace MetadataProvider
 				case SRM.ILOpCode.Newarr:
 					instruction = ProcessCreateArray(operation);
 					break;
-
+				
 				case SRM.ILOpCode.Ldelem:
 					instruction = ProcessLoadArrayElement(operation,  new ArrayType(GetOperand<IType>(operation)), LoadArrayElementOperation.Content);
+					break;
+				case SRM.ILOpCode.Ldelem_i:
+					instruction = ProcessLoadArrayElement(operation,  new ArrayType(PlatformTypes.IntPtr), LoadArrayElementOperation.Content);
 					break;
 				case SRM.ILOpCode.Ldelem_i1:
 					instruction = ProcessLoadArrayElement(operation, new ArrayType(PlatformTypes.Int8), LoadArrayElementOperation.Content);

--- a/MetadataProvider/AssemblyExtractor.cs
+++ b/MetadataProvider/AssemblyExtractor.cs
@@ -1233,12 +1233,6 @@ namespace MetadataProvider
 						break;
 					}
 
-				case OperandType.TypeDefinition:
-				{
-					var handle = (SRM.TypeDefinitionHandle)op.Operand;
-					result = (T)(object)GetDefinedType(handle);
-					break;					
-				}
 				default:
 					throw op.OperandType.ToUnknownValueException();
 			}

--- a/MetadataProvider/AssemblyExtractor.cs
+++ b/MetadataProvider/AssemblyExtractor.cs
@@ -782,22 +782,40 @@ namespace MetadataProvider
 					break;
 
 				case SRM.ILOpCode.Ldelem:
-				case SRM.ILOpCode.Ldelem_i:
-				case SRM.ILOpCode.Ldelem_i1:
-				case SRM.ILOpCode.Ldelem_i2:
-				case SRM.ILOpCode.Ldelem_i4:
-				case SRM.ILOpCode.Ldelem_i8:
-				case SRM.ILOpCode.Ldelem_r4:
-				case SRM.ILOpCode.Ldelem_r8:
-				case SRM.ILOpCode.Ldelem_u1:
-				case SRM.ILOpCode.Ldelem_u2:
-				case SRM.ILOpCode.Ldelem_u4:
-				case SRM.ILOpCode.Ldelem_ref:
-					instruction = ProcessBasic(operation);
+					instruction = ProcessLoadArrayElement(operation,  new ArrayType(GetOperand<IType>(operation)), LoadArrayElementOperation.Content);
 					break;
-
+				case SRM.ILOpCode.Ldelem_i1:
+					instruction = ProcessLoadArrayElement(operation, new ArrayType(PlatformTypes.Int8), LoadArrayElementOperation.Content);
+					break;
+				case SRM.ILOpCode.Ldelem_i2:
+					instruction = ProcessLoadArrayElement(operation, new ArrayType(PlatformTypes.Int16), LoadArrayElementOperation.Content);
+					break;
+				case SRM.ILOpCode.Ldelem_i4:
+					instruction = ProcessLoadArrayElement(operation, new ArrayType(PlatformTypes.Int32), LoadArrayElementOperation.Content);
+					break;
+				case SRM.ILOpCode.Ldelem_i8:
+					instruction = ProcessLoadArrayElement(operation, new ArrayType(PlatformTypes.Int64), LoadArrayElementOperation.Content);
+					break;
+				case SRM.ILOpCode.Ldelem_r4:
+					instruction = ProcessLoadArrayElement(operation, new ArrayType(PlatformTypes.Float32), LoadArrayElementOperation.Content);
+					break;
+				case SRM.ILOpCode.Ldelem_r8:
+					instruction = ProcessLoadArrayElement(operation, new ArrayType(PlatformTypes.Float64), LoadArrayElementOperation.Content);
+					break;
+				case SRM.ILOpCode.Ldelem_u1:
+					instruction = ProcessLoadArrayElement(operation, new ArrayType(PlatformTypes.UInt8), LoadArrayElementOperation.Content);
+					break;
+				case SRM.ILOpCode.Ldelem_u2:
+					instruction = ProcessLoadArrayElement(operation, new ArrayType(PlatformTypes.UInt16), LoadArrayElementOperation.Content);
+					break;
+				case SRM.ILOpCode.Ldelem_u4:
+					instruction = ProcessLoadArrayElement(operation, new ArrayType(PlatformTypes.UInt32), LoadArrayElementOperation.Content);
+					break;
+				case SRM.ILOpCode.Ldelem_ref: 
+					instruction = ProcessLoadArrayElement(operation, new ArrayType(PlatformTypes.Object), LoadArrayElementOperation.Content);
+					break;
 				case SRM.ILOpCode.Ldelema:
-					instruction = ProcessBasic(operation);
+					instruction = ProcessLoadArrayElement(operation, new ArrayType(GetOperand<IType>(operation)), LoadArrayElementOperation.Address);
 					break;
 
 				case SRM.ILOpCode.Beq:
@@ -1212,6 +1230,12 @@ namespace MetadataProvider
 						break;
 					}
 
+				case OperandType.TypeDefinition:
+				{
+					var handle = (SRM.TypeDefinitionHandle)op.Operand;
+					result = (T)(object)GetDefinedType(handle);
+					break;					
+				}
 				default:
 					throw op.OperandType.ToUnknownValueException();
 			}

--- a/MetadataProvider/OperationHelper.cs
+++ b/MetadataProvider/OperationHelper.cs
@@ -69,19 +69,6 @@ namespace MetadataProvider
 				case SRM.ILOpCode.Ldind_u2:
 				case SRM.ILOpCode.Ldind_u4:
 				case SRM.ILOpCode.Ldobj:		return BasicOperation.IndirectLoad;
-				case SRM.ILOpCode.Ldelem:
-				case SRM.ILOpCode.Ldelem_i:
-				case SRM.ILOpCode.Ldelem_i1:
-				case SRM.ILOpCode.Ldelem_i2:
-				case SRM.ILOpCode.Ldelem_i4:
-				case SRM.ILOpCode.Ldelem_i8:
-				case SRM.ILOpCode.Ldelem_r4:
-				case SRM.ILOpCode.Ldelem_r8:
-				case SRM.ILOpCode.Ldelem_u1:
-				case SRM.ILOpCode.Ldelem_u2:
-				case SRM.ILOpCode.Ldelem_u4:
-				case SRM.ILOpCode.Ldelem_ref:	return BasicOperation.LoadArrayElement;
-				case SRM.ILOpCode.Ldelema:		return BasicOperation.LoadArrayElementAddress;
 				case SRM.ILOpCode.Stind_i:
 				case SRM.ILOpCode.Stind_i1:
 				case SRM.ILOpCode.Stind_i2:

--- a/Model/Bytecode/Instructions.cs
+++ b/Model/Bytecode/Instructions.cs
@@ -260,6 +260,7 @@ namespace Model.Bytecode
 			return this.ToString("new {0}", this.Type);
 		}
 	}
+	
 	public class LoadArrayElementInstruction : Instruction
     {
 		public LoadArrayElementOperation Operation { get; set; }

--- a/Model/Bytecode/Instructions.cs
+++ b/Model/Bytecode/Instructions.cs
@@ -41,8 +41,6 @@ namespace Model.Bytecode
 		CopyBlock,
 		LoadArrayLength,
 		IndirectLoad,
-		LoadArrayElement,
-		LoadArrayElementAddress,
 		IndirectStore,
 		StoreArrayElement,
 		Breakpoint,
@@ -262,7 +260,6 @@ namespace Model.Bytecode
 			return this.ToString("new {0}", this.Type);
 		}
 	}
-
 	public class LoadArrayElementInstruction : Instruction
     {
 		public LoadArrayElementOperation Operation { get; set; }


### PR DESCRIPTION
LoadArrayElement instructions are being processed as BasicInstruction and thus missing the arguments they can have:
![image](https://user-images.githubusercontent.com/11294826/70866368-96b7fa00-1f47-11ea-9c2f-90a542647a4b.png)

![image](https://user-images.githubusercontent.com/11294826/70866370-a0d9f880-1f47-11ea-970b-90e8b2c352f3.png)

There are some variants of the instructions that don't need arguments though: `ldelem.i1`, `ldelem.i2`, `ldelem.ref`, etc

**Depends on**: https://github.com/edgardozoppi/analysis-net/pull/34