### PR TITLE
Convert instruction now supports IsInst

### DIFF
--- a/CCIProvider/OperationHelper.cs
+++ b/CCIProvider/OperationHelper.cs
@@ -109,9 +109,9 @@ namespace CCIProvider
 		public static ConvertOperation ToConvertOperation(Cci.OperationCode opcode)
 		{
 			switch (opcode)
-			{
-				case Cci.OperationCode.Castclass:
-				case Cci.OperationCode.Isinst:		return ConvertOperation.Cast;
+			{					
+				case Cci.OperationCode.Isinst:	    return  ConvertOperation.IsInst;
+				case Cci.OperationCode.Castclass:	return ConvertOperation.Cast;
 				case Cci.OperationCode.Box:			return ConvertOperation.Box;
 				case Cci.OperationCode.Unbox:		return ConvertOperation.UnboxPtr;
 				case Cci.OperationCode.Unbox_Any:	return ConvertOperation.Unbox;

--- a/MetadataProvider/AssemblyExtractor.cs
+++ b/MetadataProvider/AssemblyExtractor.cs
@@ -1212,13 +1212,6 @@ namespace MetadataProvider
 						break;
 					}
 				
-				case OperandType.TypeDefinition:
-				{
-					var handle = (SRM.TypeDefinitionHandle)op.Operand;
-					result = (T)(object)GetDefinedType(handle);
-					break;					
-				}
-
 				default:
 					throw op.OperandType.ToUnknownValueException();
 			}

--- a/MetadataProvider/AssemblyExtractor.cs
+++ b/MetadataProvider/AssemblyExtractor.cs
@@ -1211,7 +1211,7 @@ namespace MetadataProvider
 						result = (T)GetMethodReference(handle);
 						break;
 					}
-				
+
 				default:
 					throw op.OperandType.ToUnknownValueException();
 			}

--- a/MetadataProvider/AssemblyExtractor.cs
+++ b/MetadataProvider/AssemblyExtractor.cs
@@ -1211,6 +1211,13 @@ namespace MetadataProvider
 						result = (T)GetMethodReference(handle);
 						break;
 					}
+				
+				case OperandType.TypeDefinition:
+				{
+					var handle = (SRM.TypeDefinitionHandle)op.Operand;
+					result = (T)(object)GetDefinedType(handle);
+					break;					
+				}
 
 				default:
 					throw op.OperandType.ToUnknownValueException();

--- a/MetadataProvider/OperationHelper.cs
+++ b/MetadataProvider/OperationHelper.cs
@@ -110,8 +110,8 @@ namespace MetadataProvider
 		{
 			switch (opcode)
 			{
-				case SRM.ILOpCode.Castclass:
-				case SRM.ILOpCode.Isinst:		 return ConvertOperation.Cast;
+				case SRM.ILOpCode.Isinst:		 return  ConvertOperation.IsInst;
+				case SRM.ILOpCode.Castclass:     return ConvertOperation.Cast;
 				case SRM.ILOpCode.Box:			 return ConvertOperation.Box;
 				case SRM.ILOpCode.Unbox:		 return ConvertOperation.UnboxPtr;
 				case SRM.ILOpCode.Unbox_any:	 return ConvertOperation.Unbox;

--- a/Model/Bytecode/Instructions.cs
+++ b/Model/Bytecode/Instructions.cs
@@ -66,6 +66,7 @@ namespace Model.Bytecode
 	public enum ConvertOperation
 	{
 		Conv,
+		IsInst,
 		Cast,
 		Box,
 		Unbox,


### PR DESCRIPTION
Both `cast` and `isinst` cil instructions are treated as a Convert Instruction of type `Cast`. To write it back to cil (from the model) it is necessary that these cases are differentiated.