### PR TITLE
Differenciate pointers and managed pointers

### DIFF
--- a/MetadataProvider/SignatureTypeProvider.cs
+++ b/MetadataProvider/SignatureTypeProvider.cs
@@ -149,7 +149,7 @@ namespace MetadataProvider
 
 		public virtual IType GetByReferenceType(IType targetType)
 		{
-			var result = new PointerType(targetType);
+			var result = new ManagedPointerType(targetType);
 			return result;
 		}
 

--- a/MetadataProvider/SignatureTypeProvider.cs
+++ b/MetadataProvider/SignatureTypeProvider.cs
@@ -149,7 +149,7 @@ namespace MetadataProvider
 
 		public virtual IType GetByReferenceType(IType targetType)
 		{
-			var result = new ManagedPointerType(targetType);
+			var result = new PointerType(targetType, true);
 			return result;
 		}
 

--- a/Model/Types/Types.cs
+++ b/Model/Types/Types.cs
@@ -650,53 +650,19 @@ namespace Model.Types
 			return result;
 		}
 	}
-	
-	public class ManagedPointerType : IReferenceType
-	{
-		public ISet<CustomAttribute> Attributes { get; private set; }
-		public IType TargetType { get; set; }
-
-		public ManagedPointerType(IType targetType)
-		{
-			this.TargetType = targetType;
-			this.Attributes = new HashSet<CustomAttribute>();
-		}
-
-		public TypeKind TypeKind
-		{
-			get { return TypeKind.ReferenceType; }
-		}
-
-		public override string ToString()
-		{
-			return string.Format("{0}&", this.TargetType);
-		}
-
-		public override int GetHashCode()
-		{
-			return this.TargetType.GetHashCode();
-		}
-
-		public override bool Equals(object obj)
-		{
-			var other = obj as ManagedPointerType;
-
-			var result = other != null &&
-			             this.TargetType.Equals(other.TargetType);
-
-			return result;
-		}
-	}
 
 	public class PointerType : IReferenceType
 	{
 		public ISet<CustomAttribute> Attributes { get; private set; }
 		public IType TargetType { get; set; }
 
-		public PointerType(IType targetType)
+		public bool Managed { get; private set; }
+
+		public PointerType(IType targetType, bool managed = false)
 		{
 			this.TargetType = targetType;
 			this.Attributes = new HashSet<CustomAttribute>();
+			this.Managed = managed;
 		}
 
 		public TypeKind TypeKind
@@ -711,7 +677,7 @@ namespace Model.Types
 
 		public override int GetHashCode()
 		{
-			return this.TargetType.GetHashCode();
+			return this.TargetType.GetHashCode() ^ this.Managed.GetHashCode();
 		}
 
 		public override bool Equals(object obj)
@@ -719,7 +685,8 @@ namespace Model.Types
 			var other = obj as PointerType;
 
 			var result = other != null &&
-						 this.TargetType.Equals(other.TargetType);
+						 this.TargetType.Equals(other.TargetType) &&
+						 this.Managed.Equals(other.Managed);
 
 			return result;
 		}

--- a/Model/Types/Types.cs
+++ b/Model/Types/Types.cs
@@ -650,6 +650,43 @@ namespace Model.Types
 			return result;
 		}
 	}
+	
+	public class ManagedPointerType : IReferenceType
+	{
+		public ISet<CustomAttribute> Attributes { get; private set; }
+		public IType TargetType { get; set; }
+
+		public ManagedPointerType(IType targetType)
+		{
+			this.TargetType = targetType;
+			this.Attributes = new HashSet<CustomAttribute>();
+		}
+
+		public TypeKind TypeKind
+		{
+			get { return TypeKind.ReferenceType; }
+		}
+
+		public override string ToString()
+		{
+			return string.Format("{0}&", this.TargetType);
+		}
+
+		public override int GetHashCode()
+		{
+			return this.TargetType.GetHashCode();
+		}
+
+		public override bool Equals(object obj)
+		{
+			var other = obj as ManagedPointerType;
+
+			var result = other != null &&
+			             this.TargetType.Equals(other.TargetType);
+
+			return result;
+		}
+	}
 
 	public class PointerType : IReferenceType
 	{


### PR DESCRIPTION
In CIL pointers are encoded as `*` and managed pointers as `&`. To be able to generate this correctly, they need to be differentiated in the model.