### PR TITLE
Metadata Provider fixes & enhancements

### DIFF
--- a/Backend/Utils/Helper.cs
+++ b/Backend/Utils/Helper.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Model;
 
 namespace Backend.Utils
 {

--- a/CCIProvider/TypeExtractor.cs
+++ b/CCIProvider/TypeExtractor.cs
@@ -7,7 +7,16 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Microsoft.Cci.MutableCodeModel;
+using AssemblyReference = Model.AssemblyReference;
 using Cci = Microsoft.Cci;
+using CustomAttribute = Model.Types.CustomAttribute;
+using FieldDefinition = Model.Types.FieldDefinition;
+using FieldReference = Model.Types.FieldReference;
+using GenericParameter = Model.Types.GenericParameter;
+using MethodBody = Model.Types.MethodBody;
+using MethodDefinition = Model.Types.MethodDefinition;
+using MethodReference = Model.Types.MethodReference;
 
 namespace CCIProvider
 {
@@ -810,7 +819,22 @@ namespace CCIProvider
 				var index = (ushort)i;
 				var name = parameterdef.Name.Value;
 				var typeKind = GetGenericParameterTypeKind(parameterdef);
-				var parameter = new GenericParameter(GenericParameterKind.Type, index, name, typeKind);
+				var variance = GenericParameterVariance.NONE;
+				switch (parameterdef.Variance)
+				{
+					case Cci.TypeParameterVariance.Contravariant:
+						variance = GenericParameterVariance.CONTRAVARIANT;
+						break;
+					case Cci.TypeParameterVariance.Covariant:
+						variance = GenericParameterVariance.COVARIANT;
+						break;
+				}
+
+				var parameter = new GenericParameter(GenericParameterKind.Type, index, name, typeKind)
+				{
+					Variance = variance,
+					DefaultConstructorConstraint = parameterdef.MustHaveDefaultConstructor
+				};
 
 				ExtractAttributes(parameter.Attributes, parameterdef.Attributes);
 

--- a/CCIProvider/TypeExtractor.cs
+++ b/CCIProvider/TypeExtractor.cs
@@ -7,16 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using Microsoft.Cci.MutableCodeModel;
-using AssemblyReference = Model.AssemblyReference;
 using Cci = Microsoft.Cci;
-using CustomAttribute = Model.Types.CustomAttribute;
-using FieldDefinition = Model.Types.FieldDefinition;
-using FieldReference = Model.Types.FieldReference;
-using GenericParameter = Model.Types.GenericParameter;
-using MethodBody = Model.Types.MethodBody;
-using MethodDefinition = Model.Types.MethodDefinition;
-using MethodReference = Model.Types.MethodReference;
 
 namespace CCIProvider
 {

--- a/CCIProvider/TypeExtractor.cs
+++ b/CCIProvider/TypeExtractor.cs
@@ -818,7 +818,8 @@ namespace CCIProvider
 				definingType.GenericParameters.Add(parameter);
 
 				defGenericContext.TypeParameters.Add(parameter);
-			}
+                parameter.Constraints.AddRange(parameterdef.Constraints.Select(cciTypeRef => ExtractType(cciTypeRef)));
+            }
 		}
 
 		private static IList<Cci.IGenericTypeParameter> GetAllGenericTypeParameters(Cci.ITypeDefinition typedef)

--- a/MetadataProvider/AssemblyExtractor.cs
+++ b/MetadataProvider/AssemblyExtractor.cs
@@ -63,7 +63,7 @@ namespace MetadataProvider
 				result = new TypeDefinition(name)
 				{
 					ContainingAssembly = assembly,
-					ContainingNamespace =  currentNamespace
+					ContainingNamespace = new Namespace(metadata.GetString(typedef.Namespace))
 				};
 				
 				foreach (var genericParameterHandle in typedef.GetGenericParameters())
@@ -196,6 +196,8 @@ namespace MetadataProvider
 			}
 
 			type.ContainingType = currentType;
+			type.ContainingAssembly = assembly;
+			type.ContainingNamespace = currentNamespace;
 			currentType = type;
 
 			foreach (var genericParameter in type.GenericParameters)

--- a/MetadataProvider/AssemblyExtractor.cs
+++ b/MetadataProvider/AssemblyExtractor.cs
@@ -642,8 +642,7 @@ namespace MetadataProvider
 
 				var v = new LocalVariable("this", true)
 				{
-					Type = type,
-					Index = parameters.Count
+					Type = type
 				};
 				parameters.Add(v);
 			}
@@ -652,8 +651,7 @@ namespace MetadataProvider
 			{
 				var v = new LocalVariable(parameter.Name, true)
 				{
-					Type = parameter.Type,
-					Index = parameters.Count
+					Type = parameter.Type
 				};
 
 				parameters.Add(v);
@@ -672,8 +670,7 @@ namespace MetadataProvider
 				var type = types[i];
 				var v = new LocalVariable(name)
 				{
-					Type = type,
-					Index = i
+					Type = type
 				};
 
 				variables.Add(v);

--- a/MetadataProvider/AssemblyExtractor.cs
+++ b/MetadataProvider/AssemblyExtractor.cs
@@ -129,6 +129,8 @@ namespace MetadataProvider
 				Culture = metadata.GetString(assemblydef.Culture),
 				PublicKey = metadata.GetBlobBytes(assemblydef.PublicKey)
 			};
+			
+			ExtractAttributes(assembly, assemblydef.GetCustomAttributes());
 
 			foreach (var handle in metadata.AssemblyReferences)
 			{

--- a/MetadataProvider/AssemblyExtractor.cs
+++ b/MetadataProvider/AssemblyExtractor.cs
@@ -123,7 +123,9 @@ namespace MetadataProvider
 			var name = metadata.GetString(assemblydef.Name);
 			assembly = new Assembly(name) 
 			{
-				Version = assemblydef.Version
+				Version = assemblydef.Version,
+				Culture = metadata.GetString(assemblydef.Culture),
+				PublicKey = metadata.GetBlobBytes(assemblydef.PublicKey)
 			};
 
 			foreach (var handle in metadata.AssemblyReferences)
@@ -132,7 +134,9 @@ namespace MetadataProvider
 				name = metadata.GetString(referencedef.Name);
 				var reference = new AssemblyReference(name)
 				{
-					Version = referencedef.Version
+					Version = referencedef.Version,
+					Culture = metadata.GetString(referencedef.Culture),
+					PublicKey = metadata.GetBlobBytes(referencedef.PublicKeyOrToken)
 				};
 
 				assembly.References.Add(reference);

--- a/MetadataProvider/AssemblyExtractor.cs
+++ b/MetadataProvider/AssemblyExtractor.cs
@@ -400,10 +400,23 @@ namespace MetadataProvider
 				typeKind = TypeKind.ValueType;
 			}
 
+			var variance = GenericParameterVariance.NONE;
+			if (genericParameterdef.Attributes.HasFlag(SR.GenericParameterAttributes.Contravariant))
+			{
+				variance = GenericParameterVariance.CONTRAVARIANT;
+			}
+
+			if (genericParameterdef.Attributes.HasFlag(SR.GenericParameterAttributes.Covariant))
+			{
+				variance = GenericParameterVariance.COVARIANT;
+			}
+
 			var name = metadata.GetString(genericParameterdef.Name);
 			var genericParameter = new GenericParameter(parameterKind, (ushort)genericParameterdef.Index, name, typeKind)
 			{
-				GenericContainer = genericContainer
+				GenericContainer = genericContainer,
+				Variance = variance,
+				DefaultConstructorConstraint =  genericParameterdef.Attributes.HasFlag(SR.GenericParameterAttributes.DefaultConstructorConstraint)
 			};
 
 			genericContainer.GenericParameters.Add(genericParameter);

--- a/MetadataProvider/AssemblyExtractor.cs
+++ b/MetadataProvider/AssemblyExtractor.cs
@@ -58,14 +58,19 @@ namespace MetadataProvider
 			{
 				var typedef = metadata.GetTypeDefinition(handle);
 				var name = metadata.GetString(typedef.Name);
-				name = GetGenericName(name, out var genericParameterCount);
+				name = GetGenericName(name);
 
 				result = new TypeDefinition(name)
 				{
-					GenericParameterCount = genericParameterCount,
 					ContainingAssembly = assembly,
 					ContainingNamespace =  currentNamespace
 				};
+				
+				foreach (var genericParameterHandle in typedef.GetGenericParameters())
+				{
+					ExtractGenericParameter(GenericParameterKind.Type, result, genericParameterHandle);
+				}
+				
 				definedTypes.Add(handle, result);
 			}
 
@@ -81,13 +86,14 @@ namespace MetadataProvider
 			{
 				var methoddef = metadata.GetMethodDefinition(handle);
 				var name = metadata.GetString(methoddef.Name);
-				name = GetGenericName(name, out _);
+				name = GetGenericName(name);
 
 				result = new MethodDefinition(name, null);
 				foreach (var genericParameterHandle in methoddef.GetGenericParameters())
 				{
 					ExtractGenericParameter(GenericParameterKind.Method, result, genericParameterHandle);
 				}
+				
 				definedMethods.Add(handle, result);
 			}
 
@@ -190,13 +196,11 @@ namespace MetadataProvider
 			}
 
 			type.ContainingType = currentType;
-			type.ContainingAssembly = assembly;
-			type.ContainingNamespace = currentNamespace;
 			currentType = type;
 
-			foreach (var handle in typedef.GetGenericParameters())
+			foreach (var genericParameter in type.GenericParameters)
 			{
-				ExtractGenericParameter(GenericParameterKind.Type, type, handle);
+				defGenericContext.TypeParameters.Add(genericParameter);
 			}
 
 			ExtractBaseType(typedef.BaseType);
@@ -396,19 +400,6 @@ namespace MetadataProvider
 				GenericContainer = genericContainer
 			};
 
-			if (parameterKind == GenericParameterKind.Type)
-			{
-				defGenericContext.TypeParameters.Add(genericParameter);
-			}
-			else if (parameterKind == GenericParameterKind.Method)
-			{
-				defGenericContext.MethodParameters.Add(genericParameter);
-			}
-			else
-			{
-				throw parameterKind.ToUnknownValueException();
-			}
-
 			genericContainer.GenericParameters.Add(genericParameter);
 		}
 
@@ -460,7 +451,7 @@ namespace MetadataProvider
 				Getter = !getter.IsNil ? GetDefinedMethod(getter) : default,
 				Setter = !setter.IsNil ? GetDefinedMethod(setter) : default,
 				ContainingType = currentType,
-				IsInstanceProperty = signature.Header.IsInstance
+				IsStatic = !signature.Header.IsInstance
 			};
 			currentType.PropertyDefinitions.Add(property);
 			BindGenericParameterReferences(GenericParameterKind.Type, currentType);
@@ -482,9 +473,9 @@ namespace MetadataProvider
 			currentType.Methods.Add(method);
 			currentMethod = method;
 
-			foreach (var handle in methoddef.GetGenericParameters())
+			foreach (var genericParameter in method.GenericParameters)
 			{
-				ExtractGenericParameter(GenericParameterKind.Method, method, handle);
+				defGenericContext.MethodParameters.Add(genericParameter);
 			}
 
 			var signature = methoddef.DecodeSignature(signatureTypeProvider, defGenericContext);
@@ -940,10 +931,16 @@ namespace MetadataProvider
 					break;
 
 				case SRM.ILOpCode.Ldfld:
+					instruction = ProcessLoadField(operation, false);
+					break;
 				case SRM.ILOpCode.Ldsfld:
+					instruction = ProcessLoadField(operation, true);
+					break;
 				case SRM.ILOpCode.Ldflda:
+					instruction = ProcessLoadField(operation, false);
+					break;
 				case SRM.ILOpCode.Ldsflda:
-					instruction = ProcessLoadField(operation);
+					instruction = ProcessLoadField(operation, true);
 					break;
 
 				case SRM.ILOpCode.Ldftn:
@@ -1058,8 +1055,10 @@ namespace MetadataProvider
 					break;
 
 				case SRM.ILOpCode.Stfld:
+					instruction = ProcessStoreField(operation, false);
+					break;
 				case SRM.ILOpCode.Stsfld:
-					instruction = ProcessStoreField(operation);
+					instruction = ProcessStoreField(operation, true);
 					break;
 
 				case SRM.ILOpCode.Stind_i:
@@ -1544,11 +1543,12 @@ namespace MetadataProvider
 			return instruction;
 		}
 
-		private IInstruction ProcessLoadField(ILInstruction op)
+		private IInstruction ProcessLoadField(ILInstruction op, bool isStatic)
 		{
 			var operation = OperationHelper.ToLoadFieldOperation(op.Opcode);
 			var field = GetOperand<IFieldReference>(op);
 
+			SetFieldStaticProperty(field, isStatic);
 			var instruction = new LoadFieldInstruction(op.Offset, operation, field);
 			return instruction;
 		}
@@ -1588,10 +1588,11 @@ namespace MetadataProvider
 			return instruction;
 		}
 
-		private IInstruction ProcessStoreField(ILInstruction op)
+		private IInstruction ProcessStoreField(ILInstruction op, bool isStatic)
 		{
 			var field = GetOperand<IFieldReference>(op);
-
+			
+			SetFieldStaticProperty(field, isStatic);
 			var instruction = new StoreFieldInstruction(op.Offset, field);
 			return instruction;
 		}
@@ -1615,11 +1616,7 @@ namespace MetadataProvider
 			var unsigned = OperationHelper.OperandsAreUnsigned(op.Opcode);
 			var type = GetOperand<IType>(op);
 
-			if (operation == ConvertOperation.Box && type.TypeKind == TypeKind.ValueType)
-			{
-				type = PlatformTypes.Object;
-			}
-			else if (operation == ConvertOperation.Conv)
+			if (operation == ConvertOperation.Conv)
 			{
 				type = OperationHelper.GetOperationType(op.Opcode);
 			}
@@ -1632,19 +1629,38 @@ namespace MetadataProvider
 
 		#endregion
 
-		private static string GetGenericName(string name, out int genericParameterCount)
+		private static string GetGenericName(string name)
 		{
 			var start = name.LastIndexOf('`');
-			genericParameterCount = 0;
-
+			
 			if (start > -1)
 			{
-				var count = name.Substring(start + 1);
-				genericParameterCount = Convert.ToInt32(count);
 				name = name.Remove(start);
 			}
 
 			return name;
+		}
+		
+		// FIXME
+		// Metadata static indicator for FieldReferences (!signatureHeader.IsInstance) appears to be incorrect when read. Maybe it is updated when
+		// it can resolve the reference. So field isStatic is ensured with the field operation kind (ex: stsfld => static, ldfld => not static)
+		private static void SetFieldStaticProperty(IFieldReference field, bool isStatic)
+		{
+			switch (field)
+			{
+				case FieldReference fieldReference:
+				{
+					fieldReference.IsStatic = isStatic;
+					break;
+				}
+				case FieldDefinition fieldDefinition:
+				{
+					fieldDefinition.IsStatic = isStatic;
+					break;
+				}
+				default: throw new Exception("case not handled");
+
+			}
 		}
 	}
 }

--- a/MetadataProvider/AssemblyExtractor.cs
+++ b/MetadataProvider/AssemblyExtractor.cs
@@ -459,7 +459,11 @@ namespace MetadataProvider
 			}
 
 			genericContainer.GenericParameters.Add(genericParameter);
-		}
+            var constraints = genericParameterdef.GetConstraints().Select(
+                constraint => signatureTypeProvider.GetTypeFromHandle(metadata, defGenericContext, metadata.GetGenericParameterConstraint(constraint).Type
+            ));
+            genericParameter.Constraints.AddRange(constraints);
+        }
 
 		private void ExtractField(SRM.FieldDefinitionHandle handle)
 		{

--- a/MetadataProvider/CustomAttributeTypeProvider.cs
+++ b/MetadataProvider/CustomAttributeTypeProvider.cs
@@ -1,0 +1,33 @@
+using System.Reflection.Metadata;
+using Model.Types;
+
+namespace MetadataProvider
+{
+    internal class CustomAttributeTypeProvider : ICustomAttributeTypeProvider<IType>
+    {
+        private readonly SignatureTypeProvider signatureTypeProvider;
+
+        public CustomAttributeTypeProvider(SignatureTypeProvider signatureTypeProvider)
+        {
+            this.signatureTypeProvider = signatureTypeProvider;
+        }
+
+        public IType GetPrimitiveType(PrimitiveTypeCode typeCode) => signatureTypeProvider.GetPrimitiveType(typeCode);
+
+        public IType GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind) =>
+            signatureTypeProvider.GetTypeFromDefinition(reader, handle, rawTypeKind);
+
+        public IType GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind) =>
+            signatureTypeProvider.GetTypeFromReference(reader, handle, rawTypeKind);
+
+        public IType GetSZArrayType(IType elementType) => signatureTypeProvider.GetSZArrayType(elementType);
+
+        public IType GetSystemType() => PlatformTypes.Type;
+
+        public bool IsSystemType(IType type) => PlatformTypes.Type.Equals(type);
+
+        public IType GetTypeFromSerializedName(string name) => new BasicType(name);
+
+        public PrimitiveTypeCode GetUnderlyingEnumType(IType type) => PrimitiveTypeCode.Int32;
+    }
+}

--- a/MetadataProvider/MetadataProvider.csproj
+++ b/MetadataProvider/MetadataProvider.csproj
@@ -49,6 +49,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssemblyExtractor.cs" />
+    <Compile Include="CustomAttributeTypeProvider.cs" />
     <Compile Include="ILReader.cs" />
     <Compile Include="Loader.cs" />
     <Compile Include="OperationHelper.cs" />

--- a/MetadataProvider/SignatureTypeProvider.cs
+++ b/MetadataProvider/SignatureTypeProvider.cs
@@ -174,16 +174,6 @@ namespace MetadataProvider
 		public virtual IType GetGenericInstantiation(IType genericType, ImmutableArray<IType> genericArguments)
 		{
 			var result = genericType as IBasicType;
-			switch (result)
-			{
-				case BasicType basicType:
-					basicType.GenericParameterCount = genericArguments.Length;
-					break;
-				case TypeDefinition typeDefinition:
-					typeDefinition.GenericParameterCount = genericArguments.Length;
-					break;
-			}
-
 			result = result.Instantiate(genericArguments);
 			return result;
 		}

--- a/MetadataProvider/SignatureTypeProvider.cs
+++ b/MetadataProvider/SignatureTypeProvider.cs
@@ -75,7 +75,10 @@ namespace MetadataProvider
 						var assemblyHandle = (SRM.AssemblyReferenceHandle)typeref.ResolutionScope;
 						var assembly = reader.GetAssemblyReference(assemblyHandle);
 						name = reader.GetString(assembly.Name);
-						type.ContainingAssembly = new AssemblyReference(name);
+						type.ContainingAssembly = new AssemblyReference(name)
+						{
+							Version = assembly.Version
+						};
 						break;
 					}
 
@@ -171,6 +174,16 @@ namespace MetadataProvider
 		public virtual IType GetGenericInstantiation(IType genericType, ImmutableArray<IType> genericArguments)
 		{
 			var result = genericType as IBasicType;
+			switch (result)
+			{
+				case BasicType basicType:
+					basicType.GenericParameterCount = genericArguments.Length;
+					break;
+				case TypeDefinition typeDefinition:
+					typeDefinition.GenericParameterCount = genericArguments.Length;
+					break;
+			}
+
 			result = result.Instantiate(genericArguments);
 			return result;
 		}

--- a/Model/Assembly.cs
+++ b/Model/Assembly.cs
@@ -12,11 +12,13 @@ namespace Model
 	public interface IAssemblyReference
 	{
 		string Name { get; }
+		Version Version { get; }
 	}
 
 	public class AssemblyReference : IAssemblyReference
 	{
 		public string Name { get; private set; }
+		public Version Version { get; set; }
 
 		public AssemblyReference(string name)
 		{
@@ -49,7 +51,7 @@ namespace Model
 		public string Name { get; private set; }
 		public IList<IAssemblyReference> References { get; private set; }
 		public Namespace RootNamespace { get; set; }
-
+		public Version Version { get; set; }
 		public Assembly(string name)
 		{
 			this.Name = name;

--- a/Model/Assembly.cs
+++ b/Model/Assembly.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace Model
 {
-	public interface IAssemblyReference
+	public interface IAssemblyReference : IMetadataReference
 	{
 		string Name { get; }
 		Version Version { get; }
@@ -23,10 +23,11 @@ namespace Model
 		public Version Version { get; set; }
 		public string Culture { get; set; }
 		public byte[] PublicKey { get; set; }
-
+		public ISet<CustomAttribute> Attributes { get; private set; }
 		public AssemblyReference(string name)
 		{
 			this.Name = name;
+			this.Attributes = new HashSet<CustomAttribute>();
 		}
 
 		public override string ToString()
@@ -58,10 +59,12 @@ namespace Model
 		public Version Version { get; set; }
 		public string Culture { get; set; }
 		public byte[] PublicKey { get; set; }
+		public ISet<CustomAttribute> Attributes { get; private set; }
 		public Assembly(string name)
 		{
 			this.Name = name;
 			this.References = new List<IAssemblyReference>();
+			this.Attributes = new HashSet<CustomAttribute>();
 		}
 
 		public bool MatchReference(IAssemblyReference reference)

--- a/Model/Assembly.cs
+++ b/Model/Assembly.cs
@@ -13,12 +13,16 @@ namespace Model
 	{
 		string Name { get; }
 		Version Version { get; }
+		string Culture { get; }
+		byte[] PublicKey { get; }
 	}
 
 	public class AssemblyReference : IAssemblyReference
 	{
 		public string Name { get; private set; }
 		public Version Version { get; set; }
+		public string Culture { get; set; }
+		public byte[] PublicKey { get; set; }
 
 		public AssemblyReference(string name)
 		{
@@ -52,6 +56,8 @@ namespace Model
 		public IList<IAssemblyReference> References { get; private set; }
 		public Namespace RootNamespace { get; set; }
 		public Version Version { get; set; }
+		public string Culture { get; set; }
+		public byte[] PublicKey { get; set; }
 		public Assembly(string name)
 		{
 			this.Name = name;

--- a/Model/Bytecode/Instructions.cs
+++ b/Model/Bytecode/Instructions.cs
@@ -245,6 +245,8 @@ namespace Model.Bytecode
 		public ArrayType Type { get; set; }
 		public bool WithLowerBound { get; set; }
 
+		public IMethodReference Constructor { get; set; }
+
 		public CreateArrayInstruction(uint label, ArrayType type)
 			: base(label)
 		{
@@ -266,6 +268,8 @@ namespace Model.Bytecode
 	public class LoadArrayElementInstruction : Instruction
     {
 		public LoadArrayElementOperation Operation { get; set; }
+
+		public IMethodReference Method { get; set; }
 		public ArrayType Array { get; set; }
 
         public LoadArrayElementInstruction(uint label, LoadArrayElementOperation operation, ArrayType array)
@@ -290,6 +294,8 @@ namespace Model.Bytecode
 	public class StoreArrayElementInstruction : Instruction
 	{
 		public ArrayType Array { get; set; }
+		
+		public IMethodReference Method { get; set; }
 
 		public StoreArrayElementInstruction(uint label, ArrayType array)
 			: base(label)

--- a/Model/Extensions.cs
+++ b/Model/Extensions.cs
@@ -246,7 +246,7 @@ namespace Model
 				ContainingAssembly = type.ContainingAssembly,
 				ContainingNamespace = type.ContainingNamespace,
 				ContainingType = type.ContainingType,
-				GenericParameterCount = type.GenericParameterCount,
+				GenericParameterCount = genericArguments.Count(),
 				GenericType = type
 			};
 
@@ -356,6 +356,53 @@ namespace Model
 					var fullName = basicType.GetFullName();
 					result = delegateTypes.Any(name => fullName.StartsWith(name));
 				}
+			}
+
+			return result;
+		}
+
+		public static bool MatchSignature(this IMethodReference method, IMethodReference anotherMethod)
+		{
+			var result = method.Name == anotherMethod.Name &&
+			             method.IsStatic == anotherMethod.IsStatic &&
+			             method.GenericParameterCount == anotherMethod.GenericParameterCount &&
+			             method.ReturnType.Equals(anotherMethod.ReturnType) &&
+			             method.MatchParameters(anotherMethod);
+			return result;
+		}
+
+		public static bool MatchParameters(this IMethodReference method, IMethodReference anotherMethod)
+		{
+			var result = false;
+
+			if (method.Parameters.Count == anotherMethod.Parameters.Count)
+			{
+				result = true;
+
+				for (var i = 0; i < method.Parameters.Count && result; ++i)
+				{
+					var parameterdef = method.Parameters[i];
+					var parameterref = anotherMethod.Parameters[i];
+
+					result = parameterdef.MatchReference(parameterref);
+				}
+			}
+
+			return result;
+		}
+
+		public static bool MatchReference(this IMethodParameterReference parameter, IMethodParameterReference anotherParameter)
+		{
+			var result = false;
+
+			if (anotherParameter is MethodParameter)
+			{
+				result = parameter.Equals(anotherParameter);
+			}
+			else
+			{
+				result = parameter.Kind == anotherParameter.Kind &&
+				         parameter.Type.Equals(anotherParameter.Type);
 			}
 
 			return result;

--- a/Model/ThreeAddressCode/Operands.cs
+++ b/Model/ThreeAddressCode/Operands.cs
@@ -292,6 +292,9 @@ namespace Model.ThreeAddressCode.Values
 		public string Name { get; set; }
 		public IType Type { get; set; }
 		public bool IsParameter { get; set; }
+		
+		// int? because int defaults to 0 if not present
+		public int? Index { get; set; }
 
 		public LocalVariable(string name, bool isParameter = false)
 		{

--- a/Model/ThreeAddressCode/Operands.cs
+++ b/Model/ThreeAddressCode/Operands.cs
@@ -292,9 +292,7 @@ namespace Model.ThreeAddressCode.Values
 		public string Name { get; set; }
 		public IType Type { get; set; }
 		public bool IsParameter { get; set; }
-		
-		// int? because int defaults to 0 if not present
-		public int? Index { get; set; }
+		public int Index { get; set; }
 
 		public LocalVariable(string name, bool isParameter = false)
 		{

--- a/Model/ThreeAddressCode/Operands.cs
+++ b/Model/ThreeAddressCode/Operands.cs
@@ -292,7 +292,6 @@ namespace Model.ThreeAddressCode.Values
 		public string Name { get; set; }
 		public IType Type { get; set; }
 		public bool IsParameter { get; set; }
-		public int Index { get; set; }
 
 		public LocalVariable(string name, bool isParameter = false)
 		{

--- a/Model/Types/TypeDefinitions.cs
+++ b/Model/Types/TypeDefinitions.cs
@@ -397,7 +397,7 @@ namespace Model.Types
 			return result;
 		}
 	}
-	public class PropertyDefinition : ITypeMemberDefinition
+	public class PropertyDefinition : ITypeMemberDefinition, IMetadataReference
 	{
 		public PropertyDefinition(string name, IType propType)
 		{
@@ -416,7 +416,7 @@ namespace Model.Types
 		{
 			get { return this.ContainingType; }
 		}
-		public bool IsInstanceProperty { get; set; }
+		public bool IsStatic { get; set; }
 		public bool MatchReference(ITypeMemberReference member)
 		{
 			if (member is PropertyDefinition)
@@ -684,7 +684,8 @@ namespace Model.Types
 		public IBasicType UnderlayingType { get; set; }
 		public ISet<PropertyDefinition> PropertyDefinitions { get; private set; }
 		
-		public int GenericParameterCount { get; set; }
+		public int GenericParameterCount => GenericParameters.Count;
+
 		public TypeDefinition(string name, TypeKind typeKind = TypeKind.Unknown, TypeDefinitionKind kind = TypeDefinitionKind.Unknown)
 		{
 			this.Name = name;

--- a/Model/Types/TypeDefinitions.cs
+++ b/Model/Types/TypeDefinitions.cs
@@ -397,7 +397,66 @@ namespace Model.Types
 			return result;
 		}
 	}
+	public class PropertyDefinition : ITypeMemberDefinition
+	{
+		public PropertyDefinition(string name, IType propType)
+		{
+			PropertyType = propType;
+			Name = name;
+			Attributes = new HashSet<CustomAttribute>();
+		}
+ 
+		public ISet<CustomAttribute> Attributes { get; private set; }
+		public IType PropertyType { get; set; }
+		public string Name { get; set; }
+		public MethodDefinition Getter { get; set; }
+		public MethodDefinition Setter { get; set; }
+		public TypeDefinition ContainingType { get; set; }
+		IBasicType ITypeMemberReference.ContainingType
+		{
+			get { return this.ContainingType; }
+		}
+		public bool IsInstanceProperty { get; set; }
+		public bool MatchReference(ITypeMemberReference member)
+		{
+			if (member is PropertyDefinition)
+				return member.Equals(this);
 
+			return false;
+		}
+		public override bool Equals(object obj)
+		{
+			if (obj is PropertyDefinition propertyDef)
+			{
+				bool hasSetter = (propertyDef.Setter != null) == (this.Setter != null);
+				bool hasGetter = (propertyDef.Getter != null) == (this.Getter != null);
+				return  propertyDef.Name.Equals(this.Name) &&
+					propertyDef.PropertyType.Equals(this.PropertyType) &&
+					hasSetter && hasGetter &&
+					(propertyDef.Getter == null || propertyDef.Getter.Equals(this.Getter)) &&
+					(propertyDef.Setter == null || propertyDef.Setter.Equals(this.Setter)) &&
+					(propertyDef.ContainingType.Equals(this.ContainingType));
+			}
+			return false;
+		}
+		public override string ToString()
+		{
+			StringBuilder stringBuilder = new StringBuilder();
+			stringBuilder.AppendLine("Property definition");
+			stringBuilder.AppendLine(String.Format("Name: {0}", Name));
+			stringBuilder.AppendLine(String.Format("Property type: {0}", PropertyType));
+			stringBuilder.AppendLine(String.Format("Containing type: {0}", ContainingType));
+			if (Getter != null)
+			stringBuilder.AppendLine(String.Format("Getter: {0}", Getter.ToSignatureString()));
+			if (Setter != null)
+			stringBuilder.AppendLine(String.Format("Setter: {0}", Setter.ToSignatureString()));
+			return stringBuilder.ToString();
+		}
+		public override int GetHashCode()
+		{
+			return this.Name.GetHashCode();
+		}
+	}
 	public class MethodDefinition : ITypeMemberDefinition, IMethodReference, IGenericDefinition
 	{
 		public VisibilityKind Visibility { get; set; }
@@ -623,7 +682,9 @@ namespace Model.Types
 		public IList<MethodDefinition> Methods { get; private set; }
 		public IList<TypeDefinition> Types { get; private set; }
 		public IBasicType UnderlayingType { get; set; }
-
+		public ISet<PropertyDefinition> PropertyDefinitions { get; private set; }
+		
+		public int GenericParameterCount { get; set; }
 		public TypeDefinition(string name, TypeKind typeKind = TypeKind.Unknown, TypeDefinitionKind kind = TypeDefinitionKind.Unknown)
 		{
 			this.Name = name;
@@ -635,6 +696,7 @@ namespace Model.Types
 			this.Fields = new List<FieldDefinition>();
 			this.Methods = new List<MethodDefinition>();
 			this.Types = new List<TypeDefinition>();
+			this.PropertyDefinitions = new HashSet<PropertyDefinition>();
 		}
 
 		public string GenericName
@@ -675,11 +737,6 @@ namespace Model.Types
 		#endregion
 
 		#region IGenericReference members
-
-		int IGenericReference.GenericParameterCount
-		{
-			get { return this.GenericParameters.Count; }
-		}
 
 		#endregion
 

--- a/Model/Types/TypeDefinitions.cs
+++ b/Model/Types/TypeDefinitions.cs
@@ -242,23 +242,6 @@ namespace Model.Types
 			get { return this.DefaultValue != null; }
 		}
 
-		public bool MatchReference(IMethodParameterReference parameter)
-		{
-			var result = false;
-
-			if (parameter is MethodParameter)
-			{
-				result = this.Equals(parameter);
-			}
-			else
-			{
-				result = this.Kind == parameter.Kind &&
-						 this.Type.Equals(parameter.Type);
-			}
-
-			return result;
-		}
-
 		public override string ToString()
 		{
 			string kind;
@@ -472,7 +455,8 @@ namespace Model.Types
 		public bool IsConstructor { get; set; }
 		public bool IsExternal { get; set; }
 		public MethodBody Body { get; set; }
-
+		public IMethodReference OverridenMethod { get; set; }
+		
 		public MethodDefinition(string name, IType returnType)
 		{
 			this.Name = name;
@@ -564,36 +548,6 @@ namespace Model.Types
 
 				result = this.ContainingType.MatchReference(method.ContainingType) &&
 						 this.MatchSignature(method);
-			}
-
-			return result;
-		}
-
-		public bool MatchSignature(IMethodReference method)
-		{
-			var result = this.Name == method.Name &&
-						 this.IsStatic == method.IsStatic &&
-						 this.GenericParameters.Count == method.GenericParameterCount &&
-						 this.ReturnType.Equals(method.ReturnType) &&
-						 this.MatchParameters(method);
-			return result;
-		}
-
-		public bool MatchParameters(IMethodReference method)
-		{
-			var result = false;
-
-			if (this.Parameters.Count == method.Parameters.Count)
-			{
-				result = true;
-
-				for (var i = 0; i < this.Parameters.Count && result; ++i)
-				{
-					var parameterdef = this.Parameters[i];
-					var parameterref = method.Parameters[i];
-
-					result = parameterdef.MatchReference(parameterref);
-				}
 			}
 
 			return result;

--- a/Model/Types/Types.cs
+++ b/Model/Types/Types.cs
@@ -538,11 +538,20 @@ namespace Model.Types
 			return string.Format("{0}{1}", prefix, index);
 		}
 	}
+	
+	public enum GenericParameterVariance
+	{
+		COVARIANT,
+		CONTRAVARIANT,
+		NONE
+	}
 
 	public class GenericParameter : IGenericParameterReference
 	{
 		public ISet<CustomAttribute> Attributes { get; private set; }
         public ISet<IType> Constraints { get; private set; }
+        public bool DefaultConstructorConstraint { get; set; }
+        public GenericParameterVariance Variance { get; set; }
         public TypeKind TypeKind { get; set; }
 		public IGenericDefinition GenericContainer { get; set; }
 		public GenericParameterKind Kind { get; set; }

--- a/Model/Types/Types.cs
+++ b/Model/Types/Types.cs
@@ -802,12 +802,27 @@ namespace Model.Types
 
 		public int GenericParameterCount
 		{
-			get { return 0; }
+			get { return GenericParameterCountOf(Type); }
 		}
 
 		public IBasicType ContainingType
 		{
 			get { return null; }
+		}
+		
+		private int GenericParameterCountOf(IType type)
+		{
+			switch (Type.ElementsType)
+			{
+				case IGenericParameterReference genericParameterReference:
+					return genericParameterReference.GenericContainer.GenericParameterCount;
+				case ArrayType arrayType:
+					return GenericParameterCountOf(arrayType.ElementsType);
+				case PointerType pointerType:
+					return GenericParameterCountOf(pointerType.TargetType);
+				default:
+					return 0;
+			}
 		}
 	}
 

--- a/Model/Types/Types.cs
+++ b/Model/Types/Types.cs
@@ -81,6 +81,8 @@ namespace Model.Types
 
 		public static readonly BasicType Task = New("mscorlib", "System.Threading.Tasks", "Task", TypeKind.ReferenceType);
 		public static readonly BasicType GenericTask = New("mscorlib", "System.Threading.Tasks", "Task", TypeKind.ReferenceType, 1);
+		
+		public static readonly BasicType Type = New("mscorlib", "System", "Type", TypeKind.ReferenceType);
 
 		public static void Resolve(Host host)
 		{

--- a/Model/Types/Types.cs
+++ b/Model/Types/Types.cs
@@ -37,9 +37,6 @@ namespace Model.Types
 
 	public static class PlatformTypes
 	{
-		public static Boolean Includes(IType type) => platformTypes.FirstOrDefault(type.Equals) != null;
-
-
 		private static readonly ICollection<BasicType> platformTypes = new List<BasicType>();
 
 		public static readonly UnknownType Unknown = UnknownType.Value;

--- a/Model/Types/Types.cs
+++ b/Model/Types/Types.cs
@@ -37,6 +37,9 @@ namespace Model.Types
 
 	public static class PlatformTypes
 	{
+		public static Boolean Includes(IType type) => platformTypes.FirstOrDefault(type.Equals) != null;
+
+
 		private static readonly ICollection<BasicType> platformTypes = new List<BasicType>();
 
 		public static readonly UnknownType Unknown = UnknownType.Value;
@@ -732,4 +735,73 @@ namespace Model.Types
 			return result;
 		}
 	}
+	
+	#region ArrayTypeWrapper
+
+	public struct ArrayTypeWrapper : IBasicType
+	{
+		public ArrayType Type { get; }
+
+		public ArrayTypeWrapper(ArrayType type)
+		{
+			this.Type = type;
+		}
+
+		public IAssemblyReference ContainingAssembly
+		{
+			get { return null; }
+		}
+
+		public string ContainingNamespace
+		{
+			get { return string.Empty; }
+		}
+
+		public string Name
+		{
+			get { return "ArrayTypeWrapper"; }
+		}
+
+		public string GenericName
+		{
+			get { return this.Name; }
+		}
+
+		public IList<IType> GenericArguments
+		{
+			get { return null; }
+		}
+
+		public IBasicType GenericType
+		{
+			get { return null; }
+		}
+
+		public TypeDefinition ResolvedType
+		{
+			get { return null; }
+		}
+
+		public TypeKind TypeKind
+		{
+			get { return TypeKind.ReferenceType; }
+		}
+
+		public ISet<CustomAttribute> Attributes
+		{
+			get { return null; }
+		}
+
+		public int GenericParameterCount
+		{
+			get { return 0; }
+		}
+
+		public IBasicType ContainingType
+		{
+			get { return null; }
+		}
+	}
+
+	#endregion
 }

--- a/Model/Types/Types.cs
+++ b/Model/Types/Types.cs
@@ -539,7 +539,8 @@ namespace Model.Types
 	public class GenericParameter : IGenericParameterReference
 	{
 		public ISet<CustomAttribute> Attributes { get; private set; }
-		public TypeKind TypeKind { get; set; }
+        public ISet<IType> Constraints { get; private set; }
+        public TypeKind TypeKind { get; set; }
 		public IGenericDefinition GenericContainer { get; set; }
 		public GenericParameterKind Kind { get; set; }
 		public ushort Index { get; set; }
@@ -552,7 +553,8 @@ namespace Model.Types
 			this.Name = name;
 			this.TypeKind = typeKind;
 			this.Attributes = new HashSet<CustomAttribute>();
-		}
+            this.Constraints = new HashSet<IType>();
+        }
 
 		#region IGenericParameterReference members
 


### PR DESCRIPTION
Fix and add some missing features that came up when reading some libraries dlls. This Pull Request several features and changes because they were dependant on each other.

- Include Properties:
  - Model based on #27. The only difference in the model is the `IsStatic` field that was missing and is needed to generate properties.
- Include Generic Parameter Constraints:
  - Based on https://github.com/edgardozoppi/analysis-net/pull/17. Added the Variance and default constructor info that was missing and is needed for generation.
- Move `FakeArrayType` to Types since it is needed to know if a type is of this type. Also renamed it to `ArrayTypeWrapper`.
- Move some utility `MethodDefinition` methods to `Extensions` so they can be used by references as well.
- Add `Version`, `Culture` and `PublicKey` to `IAssemblyReference`.
- Include a method reference to `CreateArrayInstruction`
  - Some arrays like multidimensional ones are created with the newobj instruction that needs a method reference to its constructor.
- Include method reference to `StoreArrayElementInstruction` and `LoadArrayElementInstruction` 
  - This instructions are method calls in the bytecode and also need a method reference.
- Some fields like `ContainingAssembly`, `ContainingNamespace` and generic parameters were being set in the `ExtractType/Method/etc()` method and now they are set in the `GetDefinedType/Method/etc()` methods. This is because this info is sometimes needed before the `ExtractType/Method/etc()` is called (with references for example).
- Add `OverridenMethod` to `MethodDefinition`.
  - This points to the method that is being overriden.
  - It is needed for method generation.
- Add Custom attributes