### PR TITLE
Support for field RVA

### DIFF
--- a/Model/Types/TypeDefinitions.cs
+++ b/Model/Types/TypeDefinitions.cs
@@ -605,7 +605,25 @@ namespace Model.Types
 		Internal = 4,
 		Public = 8
 	}
-
+	public enum LayoutKind
+	{
+		Unknown,
+		AutoLayout,    // Class fields are auto-laid out
+		SequentialLayout,  // Class fields are laid out sequentially
+		ExplicitLayout,	// Layout is supplied explicitly
+	}
+	public class LayoutInformation
+	{
+		public LayoutKind Kind { get; set; }
+		public short PackingSize { get; set; }
+		public int ClassSize { get; set; }
+		public LayoutInformation(LayoutKind kind = LayoutKind.Unknown)
+		{
+			Kind = kind;
+			PackingSize = -1;
+			ClassSize = -1;
+		}
+	}
 	public class TypeDefinition : IBasicType, IGenericDefinition, ITypeMemberDefinition, ITypeDefinitionContainer
 	{
 		public TypeKind TypeKind { get; set; }
@@ -623,7 +641,7 @@ namespace Model.Types
 		public IList<MethodDefinition> Methods { get; private set; }
 		public IList<TypeDefinition> Types { get; private set; }
 		public IBasicType UnderlayingType { get; set; }
-
+		public LayoutInformation LayoutInformation { get; set; }
 		public TypeDefinition(string name, TypeKind typeKind = TypeKind.Unknown, TypeDefinitionKind kind = TypeDefinitionKind.Unknown)
 		{
 			this.Name = name;
@@ -635,6 +653,7 @@ namespace Model.Types
 			this.Fields = new List<FieldDefinition>();
 			this.Methods = new List<MethodDefinition>();
 			this.Types = new List<TypeDefinition>();
+			this.LayoutInformation = new LayoutInformation();
 		}
 
 		public string GenericName


### PR DESCRIPTION
Static fields can define their init value as a constant stored in the PE File. This is used for example to initialize static field arrays. The value is declared using the `.data` directed, represented as a `bytearray` and labeled (so it can be referenced later).