### PR TITLE
Add support for field RVA

### DIFF
--- a/MetadataProvider/AssemblyExtractor.cs
+++ b/MetadataProvider/AssemblyExtractor.cs
@@ -472,6 +472,17 @@ namespace MetadataProvider
 			field.Visibility = GetVisibilityKind(fielddef.Attributes);
 			field.Value = ExtractFieldDefaultValue(fielddef);
 
+			field.SpecifiesRelativeVirtualAddress = fielddef.Attributes.HasFlag(SR.FieldAttributes.HasFieldRVA);
+			if (field.SpecifiesRelativeVirtualAddress)
+			{
+				var fieldDataReader = reader.GetSectionData(fielddef.GetRelativeVirtualAddress()).GetReader();
+				var fieldData = fieldDataReader.ReadBytes(fieldDataReader.Length); 
+				field.Value = new Constant(fieldData)
+				{
+					Type = new ArrayType(PlatformTypes.Byte)
+				};
+			}
+			
 			currentType.Fields.Add(field);
 		}
 

--- a/Model/Types/TypeDefinitions.cs
+++ b/Model/Types/TypeDefinitions.cs
@@ -112,7 +112,7 @@ namespace Model.Types
 		public Constant Value { get; set; }
 
 		public bool IsStatic { get; set; }
-
+		public bool SpecifiesRelativeVirtualAddress { get; set; }
 		public FieldDefinition(string name, IType type)
 		{
 			this.Name = name;

--- a/Model/Types/TypeDefinitions.cs
+++ b/Model/Types/TypeDefinitions.cs
@@ -112,6 +112,7 @@ namespace Model.Types
 		public Constant Value { get; set; }
 
 		public bool IsStatic { get; set; }
+		
 		public bool SpecifiesRelativeVirtualAddress { get; set; }
 		public FieldDefinition(string name, IType type)
 		{

--- a/Model/Types/TypeDefinitions.cs
+++ b/Model/Types/TypeDefinitions.cs
@@ -112,7 +112,6 @@ namespace Model.Types
 		public Constant Value { get; set; }
 
 		public bool IsStatic { get; set; }
-		
 		public bool SpecifiesRelativeVirtualAddress { get; set; }
 		public FieldDefinition(string name, IType type)
 		{


### PR DESCRIPTION
Static fields can define their init value as a constant stored in the PE File. The value is declared using the `.data` directive, represented as a `bytearray` and labeled (so it can be referenced later).

Initialization of a static array field is an example of this. The field itself does not hold the initial value. A special type is created (`<PrivateImplementationDetails>`) that has a field that references the value declared with `.data`. It is then used in the constructor of the class that has the static array field to initialize it.