### PR TITLE
Add IsVirtual property to IMethodReference

### DIFF
--- a/MetadataProvider/AssemblyExtractor.cs
+++ b/MetadataProvider/AssemblyExtractor.cs
@@ -971,8 +971,10 @@ namespace MetadataProvider
 					break;
 
 				case SRM.ILOpCode.Ldftn:
+					instruction = ProcessLoadMethodAddress(operation, false);
+					break;
 				case SRM.ILOpCode.Ldvirtftn:
-					instruction = ProcessLoadMethodAddress(operation);
+					instruction = ProcessLoadMethodAddress(operation, true);
 					break;
 
 				case SRM.ILOpCode.Ldc_i4:
@@ -1573,10 +1575,24 @@ namespace MetadataProvider
 			return instruction;
 		}
 
-		private IInstruction ProcessLoadMethodAddress(ILInstruction op)
+		private IInstruction ProcessLoadMethodAddress(ILInstruction op, bool isVirtual)
 		{
 			var operation = OperationHelper.ToLoadMethodAddressOperation(op.Opcode);
 			var method = GetOperand<IMethodReference>(op);
+			switch (method)
+			{
+				case MethodDefinition methodDefinition:
+				{
+					methodDefinition.IsVirtual = isVirtual;
+					break;
+				}
+				case MethodReference methodReference:
+				{
+					methodReference.IsVirtual = isVirtual;
+					break;
+				}
+				default: throw new Exception("case not handled");
+			}
 
 			var instruction = new LoadMethodAddressInstruction(op.Offset, operation, method);
 			return instruction;

--- a/Model/Types/TypeDefinitions.cs
+++ b/Model/Types/TypeDefinitions.cs
@@ -286,6 +286,7 @@ namespace Model.Types
 		IMethodReference GenericMethod { get; }
 		MethodDefinition ResolvedMethod { get; }
 		bool IsStatic { get; }
+		bool IsVirtual { get; }
 	}
 
 	public class MethodReference : IMethodReference
@@ -302,6 +303,7 @@ namespace Model.Types
 		public IList<IMethodParameterReference> Parameters { get; private set; }
 		public IMethodReference GenericMethod { get; set; }
 		public bool IsStatic { get; set; }
+		public bool IsVirtual { get; set; }
 
 		public MethodReference(string name, IType returnType)
 		{


### PR DESCRIPTION
This is needed to generate either `Ldftn` or `Ldvirtftn`.