### PR TITLE
Remove PDB

### DIFF
--- a/MetadataProvider/Loader.cs
+++ b/MetadataProvider/Loader.cs
@@ -47,19 +47,16 @@ namespace MetadataProvider
                     return result;
                 };
 
-                var ok = reader.TryOpenAssociatedPortablePdb(fileName, streamProvider,
-                    out SRM.MetadataReaderProvider pdbProvider, out _);
-
-                var assembly = ExtractAssembly(reader, pdbProvider);
+                var assembly = ExtractAssembly(reader);
 
 				this.Host.Assemblies.Add(assembly);
 				return assembly;
 			}
 		}
 
-		private Assembly ExtractAssembly(SRPE.PEReader reader, SRM.MetadataReaderProvider pdbProvider)
+		private Assembly ExtractAssembly(SRPE.PEReader reader)
 		{
-			var extractor = new AssemblyExtractor(this.Host, reader, pdbProvider);
+			var extractor = new AssemblyExtractor(this.Host, reader);
 			var result = extractor.Extract();
 			return result;
 		}


### PR DESCRIPTION
PDB file is read just to determine local variables names. It is optional and even when present, not all variables have a name in the PDB file. So currently the result is a mix of real cil variable names and some generated ones for the non present names (local_$index). Besides this, cil allows multiple local variables with the same name. This change removes PDB reading to solve this last case, to unify variable names and so it is not necessary to provide the PDB file. Alternatively we can solve the name issue by assigning unique names to the ones that are duplicate. But i don't really see the point in reading the PDB optionally as it is now.