### PR TITLE
Fix generic method instantiation

### DIFF
--- a/MetadataProvider/AssemblyExtractor.cs
+++ b/MetadataProvider/AssemblyExtractor.cs
@@ -971,8 +971,10 @@ namespace MetadataProvider
 					break;
 
 				case SRM.ILOpCode.Ldftn:
+					instruction = ProcessLoadMethodAddress(operation, false);
+					break;
 				case SRM.ILOpCode.Ldvirtftn:
-					instruction = ProcessLoadMethodAddress(operation);
+					instruction = ProcessLoadMethodAddress(operation, true);
 					break;
 
 				case SRM.ILOpCode.Ldc_i4:
@@ -1573,10 +1575,24 @@ namespace MetadataProvider
 			return instruction;
 		}
 
-		private IInstruction ProcessLoadMethodAddress(ILInstruction op)
+		private IInstruction ProcessLoadMethodAddress(ILInstruction op, bool isVirtual)
 		{
 			var operation = OperationHelper.ToLoadMethodAddressOperation(op.Opcode);
 			var method = GetOperand<IMethodReference>(op);
+			switch (method)
+			{
+				case MethodDefinition methodDefinition:
+				{
+					methodDefinition.IsVirtual = isVirtual;
+					break;
+				}
+				case MethodReference methodReference:
+				{
+					methodReference.IsVirtual = isVirtual;
+					break;
+				}
+				default: throw new Exception("case not handled");
+			}
 
 			var instruction = new LoadMethodAddressInstruction(op.Offset, operation, method);
 			return instruction;

--- a/MetadataProvider/AssemblyExtractor.cs
+++ b/MetadataProvider/AssemblyExtractor.cs
@@ -1307,7 +1307,10 @@ namespace MetadataProvider
 			CreateGenericParameterReferences(GenericParameterKind.Method, genericArguments.Length);
 
 			var method = GetMethodReference(methodspec.Method);
-			method = method.Instantiate(genericArguments);
+			// method might have not been extracted yet so some properties might be missing (ex: returnType, isStatic, etc).
+			// a proxy is used instead so when the method is actually extracted, this instantiated one is also complete. Otherwise the instantiated 
+			// one will have null in some of its properties.
+			method = new MethodInstantiationProxy(method, genericArguments);
 
 			BindGenericParameterReferences(GenericParameterKind.Method, method);
 			return method;

--- a/MetadataProvider/AssemblyExtractor.cs
+++ b/MetadataProvider/AssemblyExtractor.cs
@@ -1307,9 +1307,9 @@ namespace MetadataProvider
 			CreateGenericParameterReferences(GenericParameterKind.Method, genericArguments.Length);
 
 			var method = GetMethodReference(methodspec.Method);
-			// method might have not been extracted yet so some properties might be missing (ex: returnType, isStatic, etc).
-			// a proxy is used instead so when the method is actually extracted, this instantiated one is also complete. Otherwise the instantiated 
-			// one will have null in some of its properties.
+			// method might have not been extracted yet so some fields might be missing (ex: returnType, isStatic, etc).
+			// a proxy is used instead so when the method is actually extracted, this instantiated one is updated as well.
+			// Otherwise the instantiated one would have some null fields.
 			method = new MethodInstantiationProxy(method, genericArguments);
 
 			BindGenericParameterReferences(GenericParameterKind.Method, method);

--- a/Model/Types/TypeDefinitions.cs
+++ b/Model/Types/TypeDefinitions.cs
@@ -587,6 +587,35 @@ namespace Model.Types
 			return result.ToString();
 		}
 	}
+	
+	public class MethodInstantiationProxy : IMethodReference
+	{
+		public IBasicType ContainingType => method.ContainingType;
+		public ISet<CustomAttribute> Attributes => method.Attributes;
+		public int GenericParameterCount => method.GenericParameterCount;
+		public IType ReturnType => method.ReturnType;
+		public string Name => method.Name;
+		public string GenericName => method.GenericName;
+		public IList<IMethodParameterReference> Parameters => method.Parameters;
+		public IList<IType> GenericArguments => genericArguments;
+		public IMethodReference GenericMethod => method;
+
+		public MethodDefinition ResolvedMethod =>
+			throw new InvalidOperationException("Use Resolve method to bind this reference with some host.");
+
+		public bool IsStatic => method.IsStatic;
+		public bool IsVirtual => method.IsVirtual;
+
+		private readonly IMethodReference method;
+		private readonly IList<IType> genericArguments;
+
+		public MethodInstantiationProxy(IMethodReference method, IEnumerable<IType> genericArguments)
+		{
+			this.method = method;
+			this.genericArguments = new List<IType>();
+			this.genericArguments.AddRange(genericArguments);
+		}
+	}
 
 	public enum TypeDefinitionKind
 	{

--- a/Model/Types/TypeDefinitions.cs
+++ b/Model/Types/TypeDefinitions.cs
@@ -286,6 +286,7 @@ namespace Model.Types
 		IMethodReference GenericMethod { get; }
 		MethodDefinition ResolvedMethod { get; }
 		bool IsStatic { get; }
+		bool IsVirtual { get; }
 	}
 
 	public class MethodReference : IMethodReference
@@ -302,6 +303,7 @@ namespace Model.Types
 		public IList<IMethodParameterReference> Parameters { get; private set; }
 		public IMethodReference GenericMethod { get; set; }
 		public bool IsStatic { get; set; }
+		public bool IsVirtual { get; set; }
 
 		public MethodReference(string name, IType returnType)
 		{


### PR DESCRIPTION
When obtaining an instantiated generic method reference, a method (**M1**) is obtained from a `MethodSpecificationHandle` and then instantiated using the `instantiate()` method present in the model. The issue is that the **M1** might have not been extracted/processed yet, so when that happens a method that is not complete is used instead (i.e with some null fields). The `instantiate()` method uses **M1** fields, which some of them are null, and set them to the new Instantiated method. Since this are fields, when **M1** is actually processed and updated this does not translate to the instantiated method.

A proxy is used instead to link the instantiation to **M1** so when this last one is processed, the instantiation is updated as well.


This depends on https://github.com/edgardozoppi/analysis-net/pull/44.