### PR TITLE
Fix type of "this" parameter in generic method body

### DIFF
--- a/MetadataProvider/AssemblyExtractor.cs
+++ b/MetadataProvider/AssemblyExtractor.cs
@@ -626,6 +626,12 @@ namespace MetadataProvider
 			if (!currentMethod.IsStatic)
 			{
 				IType type = currentMethod.ContainingType;
+				
+				if (currentMethod.ContainingType.GenericParameters.Count > 0)
+				{
+					// within a generic method body, "this" is not the generic type itself but its instantiation
+					type = currentMethod.ContainingType.Instantiate(currentMethod.ContainingType.GenericParameters);
+				}
 
 				if (type.TypeKind == TypeKind.ValueType)
 				{


### PR DESCRIPTION
When extracting a method, the field Parameters contains the `this` parameter if it is not static, but its type is the generic method (not instantiated). This is changed to the the instantiation of that method with its generic parameters. This means that if a method is within a type `SomeType` that has generic parameter `T`, in the method body `this` should be of that type but instantiated with the generic parameter `T`. 